### PR TITLE
bump dwn-sdk-js to `0.0.26`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "cli2",
+    "name": "dwn-cli",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
@@ -7,7 +7,7 @@
             "dependencies": {
                 "@decentralized-identity/ion-tools": "1.0.3",
                 "@scure/base": "1.1.1",
-                "@tbd54566975/dwn-sdk-js": "0.0.19",
+                "@tbd54566975/dwn-sdk-js": "0.0.26",
                 "commander": "10.0.0",
                 "lodash": "4.17.21",
                 "mkdirp": "2.1.3",
@@ -164,18 +164,17 @@
             "dev": true
         },
         "node_modules/@ipld/dag-cbor": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.1.tgz",
-            "integrity": "sha512-XqG8VEzHjQDC/Qcy5Gyf1kvAav5VuAugc6c7VtdaRLI+3d8lJrUP3F76GYJNNXuEnRZ58cCBnNNglkIGTdg1+A==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.0.tgz",
+            "integrity": "sha512-zdsiSiYDEOIDW7mmWOYWC9gukjXO+F8wqxz/LfN7iSwTfIyipC8+UQrCbPupFMRb/33XQTZk8yl3My8vUQBRoA==",
             "dependencies": {
-                "cborg": "^1.6.0",
-                "multiformats": "^9.5.4"
+                "cborg": "^1.10.0",
+                "multiformats": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
             }
-        },
-        "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
-            "version": "9.9.0",
-            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-            "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
         },
         "node_modules/@ipld/dag-pb": {
             "version": "2.1.18",
@@ -349,30 +348,35 @@
             "integrity": "sha512-aWItSZvJj4+GI6FWkjZR13xPNPctq2RRakzo+O6vN7bC2yjwdg5EFpgaSAUn95b7BGSgcflvzVDPoKmJv24IOg=="
         },
         "node_modules/@tbd54566975/dwn-sdk-js": {
-            "version": "0.0.19",
-            "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.0.19.tgz",
-            "integrity": "sha512-aiQ8TNAwDhjbvxL4bOIn70lOdJWFeT46AlvIIuVQDE+CaRp7DGFsiRWMOZuYejnN+d/NuoyPUHBDKM9tzHzNwA==",
+            "version": "0.0.26",
+            "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.0.26.tgz",
+            "integrity": "sha512-Bj+cesS5ePQ1a8k+x5DFDQFwL8gNidOicW+/+VC/KjMH2QLikCuWYdcW9A3toxPJqtTQLlfXDBp5vLeO94C7/Q==",
             "dependencies": {
-                "@ipld/dag-cbor": "7.0.1",
+                "@ipld/dag-cbor": "9.0.0",
                 "@js-temporal/polyfill": "0.4.3",
                 "@noble/ed25519": "1.7.1",
                 "@noble/secp256k1": "1.7.1",
                 "@swc/helpers": "0.3.8",
                 "@types/ms": "0.7.31",
+                "@types/node": "^18.13.0",
+                "@types/readable-stream": "2.3.15",
+                "abstract-level": "1.0.3",
                 "ajv": "8.11.0",
+                "blockstore-core": "3.0.0",
                 "cross-fetch": "3.1.5",
                 "date-fns": "2.28.0",
-                "interface-blockstore": "2.0.3",
+                "flat": "^5.0.2",
+                "interface-blockstore": "4.0.1",
                 "ipfs-unixfs": "6.0.9",
                 "ipfs-unixfs-exporter": "7.0.11",
-                "ipfs-unixfs-importer": "9.0.10",
+                "ipfs-unixfs-importer": "14.0.1",
                 "level": "8.0.0",
                 "lodash": "4.17.21",
                 "lru-cache": "7.12.0",
                 "ms": "2.1.3",
-                "multiformats": "9.6.4",
+                "multiformats": "11.0.2",
                 "randombytes": "2.1.0",
-                "search-index": "3.1.3",
+                "readable-stream": "4.3.0",
                 "uuid": "8.3.2",
                 "varint": "6.0.0"
             },
@@ -402,10 +406,36 @@
                 }
             ]
         },
+        "node_modules/@tbd54566975/dwn-sdk-js/node_modules/interface-blockstore": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-4.0.1.tgz",
+            "integrity": "sha512-ROWKGJls7vLeFaQtI3hZVCJOkUoZ05xAi2t2qysM4d7dwVKrfm5jUOqWh8JgLL7Iup3XqJ0mKXXZuwJ3s03RSw==",
+            "dependencies": {
+                "interface-store": "^3.0.0",
+                "multiformats": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/@tbd54566975/dwn-sdk-js/node_modules/interface-store": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+            "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
         "node_modules/@tbd54566975/dwn-sdk-js/node_modules/multiformats": {
-            "version": "9.6.4",
-            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.4.tgz",
-            "integrity": "sha512-fCCB6XMrr6CqJiHNjfFNGT0v//dxOBMrOMqUIzpPc/mmITweLEyhvMpY9bF+jZ9z3vaMAau5E8B68DW77QMXkg=="
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+            "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
         },
         "node_modules/@tbd54566975/dwn-sdk-js/node_modules/uuid": {
             "version": "8.3.2",
@@ -430,6 +460,31 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
             "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
         },
+        "node_modules/@types/readable-stream": {
+            "version": "2.3.15",
+            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+            "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+            "dependencies": {
+                "@types/node": "*",
+                "safe-buffer": "~5.1.1"
+            }
+        },
+        "node_modules/@types/readable-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "node_modules/abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "dependencies": {
+                "event-target-shim": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=6.5"
+            }
+        },
         "node_modules/abstract-level": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
@@ -445,30 +500,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/abstract-leveldown": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-            "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
-            "dependencies": {
-                "buffer": "^6.0.3",
-                "catering": "^2.0.0",
-                "is-buffer": "^2.0.5",
-                "level-concat-iterator": "^3.0.0",
-                "level-supports": "^2.0.1",
-                "queue-microtask": "^1.2.3"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/abstract-leveldown/node_modules/level-supports": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-            "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/acorn": {
@@ -572,6 +603,60 @@
                 "readable-stream": "^3.4.0"
             }
         },
+        "node_modules/bl/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/blockstore-core": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/blockstore-core/-/blockstore-core-3.0.0.tgz",
+            "integrity": "sha512-5ZZB5nh6kErcjZ/CTK6lCwTIGlPdkTXbD8+2xLC4Fm0WGh7g2e2lW2bfURw7mvnPtSX1xV+sN4V2ndowSgIiHQ==",
+            "dependencies": {
+                "err-code": "^3.0.1",
+                "interface-blockstore": "^4.0.0",
+                "interface-store": "^3.0.0",
+                "it-all": "^2.0.0",
+                "it-drain": "^2.0.0",
+                "it-filter": "^2.0.0",
+                "it-take": "^2.0.0",
+                "multiformats": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/blockstore-core/node_modules/interface-blockstore": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-4.0.1.tgz",
+            "integrity": "sha512-ROWKGJls7vLeFaQtI3hZVCJOkUoZ05xAi2t2qysM4d7dwVKrfm5jUOqWh8JgLL7Iup3XqJ0mKXXZuwJ3s03RSw==",
+            "dependencies": {
+                "interface-store": "^3.0.0",
+                "multiformats": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/blockstore-core/node_modules/interface-store": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+            "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -661,11 +746,6 @@
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
-        },
-        "node_modules/charwise": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
-            "integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw=="
         },
         "node_modules/classic-level": {
             "version": "1.2.0",
@@ -776,18 +856,6 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
         },
-        "node_modules/deferred-leveldown": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-7.0.0.tgz",
-            "integrity": "sha512-QKN8NtuS3BC6m0B8vAnBls44tX1WXAFATUsJlruyAYbZpysWV3siH6o/i3g9DCHauzodksO60bdj5NazNbjCmg==",
-            "dependencies": {
-                "abstract-leveldown": "^7.2.0",
-                "inherits": "^2.0.3"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -798,20 +866,6 @@
             },
             "engines": {
                 "node": ">=6.0.0"
-            }
-        },
-        "node_modules/encoding-down": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-7.1.0.tgz",
-            "integrity": "sha512-ky47X5jP84ryk5EQmvedQzELwVJPjCgXDQZGeb9F6r4PdChByCGHTBrVcF3h8ynKVJ1wVbkxTsDC8zBROPypgQ==",
-            "dependencies": {
-                "abstract-leveldown": "^7.2.0",
-                "inherits": "^2.0.3",
-                "level-codec": "^10.0.0",
-                "level-errors": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/err-code": {
@@ -1017,10 +1071,21 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/eventemitter3": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+        "node_modules/event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "engines": {
+                "node": ">=0.8.x"
+            }
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -1046,19 +1111,6 @@
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
-            }
-        },
-        "node_modules/fergies-inverted-index": {
-            "version": "10.0.6",
-            "resolved": "https://registry.npmjs.org/fergies-inverted-index/-/fergies-inverted-index-10.0.6.tgz",
-            "integrity": "sha512-T0dXoUk7XYr/N4Vgcw8MDoKtSUedYp9KxPvyYLSFbqIxDoOBPXpOktSTDaA6ToU9u9o/7u4FXtd9vJ4AoQejZg==",
-            "dependencies": {
-                "charwise": "^3.0.1",
-                "encoding-down": "^7.1.0",
-                "level-js": "^6.1.0",
-                "leveldown": "^6.1.0",
-                "levelup": "^5.1.1",
-                "traverse": "^0.6.6"
             }
         },
         "node_modules/file-entry-cache": {
@@ -1087,6 +1139,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/flat": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+            "bin": {
+                "flat": "cli.js"
             }
         },
         "node_modules/flat-cache": {
@@ -1356,35 +1416,115 @@
             "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
         },
         "node_modules/ipfs-unixfs-importer": {
-            "version": "9.0.10",
-            "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.10.tgz",
-            "integrity": "sha512-W+tQTVcSmXtFh7FWYWwPBGXJ1xDgREbIyI1E5JzDcimZLIyT5gGMfxR3oKPxxWj+GKMpP5ilvMQrbsPzWcm3Fw==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-14.0.1.tgz",
+            "integrity": "sha512-ktsXRDC3AraX6Z3NbKREOcHlcYm0o4j2J7ygJLn3N1DpIbUPNmX5z3wl45DMH5b2HIZVqnS68VxKyr9H9LLhnw==",
             "dependencies": {
-                "@ipld/dag-pb": "^2.0.2",
-                "@multiformats/murmur3": "^1.0.3",
-                "bl": "^5.0.0",
+                "@ipld/dag-pb": "^4.0.0",
+                "@multiformats/murmur3": "^2.0.0",
                 "err-code": "^3.0.1",
-                "hamt-sharding": "^2.0.0",
-                "interface-blockstore": "^2.0.3",
-                "ipfs-unixfs": "^6.0.0",
-                "it-all": "^1.0.5",
-                "it-batch": "^1.0.8",
-                "it-first": "^1.0.6",
-                "it-parallel-batch": "^1.0.9",
-                "merge-options": "^3.0.4",
-                "multiformats": "^9.4.2",
+                "hamt-sharding": "^3.0.0",
+                "interface-blockstore": "^4.0.0",
+                "ipfs-unixfs": "^11.0.0",
+                "it-all": "^2.0.0",
+                "it-batch": "^2.0.0",
+                "it-first": "^2.0.0",
+                "it-parallel-batch": "^2.0.0",
+                "multiformats": "^11.0.0",
                 "rabin-wasm": "^0.1.4",
-                "uint8arrays": "^3.0.0"
+                "uint8arraylist": "^2.4.3",
+                "uint8arrays": "^4.0.2"
             },
             "engines": {
                 "node": ">=16.0.0",
                 "npm": ">=7.0.0"
             }
         },
-        "node_modules/ipfs-unixfs-importer/node_modules/multiformats": {
-            "version": "9.9.0",
-            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-            "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+        "node_modules/ipfs-unixfs-importer/node_modules/@ipld/dag-pb": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.2.tgz",
+            "integrity": "sha512-me9oEPb7UNPWSplUFCXyxnQE3/WlsjOljqO2RZN44XOmGkBY0/WVklbXorVE1eiv0Rt3p6dBS2x36Rq8A0Am8A==",
+            "dependencies": {
+                "multiformats": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/ipfs-unixfs-importer/node_modules/@multiformats/murmur3": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.3.tgz",
+            "integrity": "sha512-YvLK1IrLnRckPsvXhOkZjaIGNonsEdD1dL3NPSaLilV/WjVYeBgnNZXTUsaPzFXGrIFM7motx+yCmmqzXO6gtQ==",
+            "dependencies": {
+                "multiformats": "^11.0.0",
+                "murmurhash3js-revisited": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/ipfs-unixfs-importer/node_modules/hamt-sharding": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.2.tgz",
+            "integrity": "sha512-f0DzBD2tSmLFdFsLAvOflIBqFPjerbA7BfmwO8mVho/5hXwgyyYhv+ijIzidQf/DpDX3bRjAQvhGoBFj+DBvPw==",
+            "dependencies": {
+                "sparse-array": "^1.3.1",
+                "uint8arrays": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/ipfs-unixfs-importer/node_modules/interface-blockstore": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-4.0.1.tgz",
+            "integrity": "sha512-ROWKGJls7vLeFaQtI3hZVCJOkUoZ05xAi2t2qysM4d7dwVKrfm5jUOqWh8JgLL7Iup3XqJ0mKXXZuwJ3s03RSw==",
+            "dependencies": {
+                "interface-store": "^3.0.0",
+                "multiformats": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/ipfs-unixfs-importer/node_modules/interface-store": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+            "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/ipfs-unixfs-importer/node_modules/ipfs-unixfs": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.0.0.tgz",
+            "integrity": "sha512-ZHTTzP5yuimLTln+8VKc3IcsO4ObS6/U8eZ3CA69s1DdW9uBfyjEo6/GTZA80yokHVGWvmCl1S28zmJ5JskP4Q==",
+            "dependencies": {
+                "err-code": "^3.0.1",
+                "protons-runtime": "^5.0.0",
+                "uint8arraylist": "^2.4.3"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/ipfs-unixfs-importer/node_modules/uint8arrays": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+            "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+            "dependencies": {
+                "multiformats": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
         },
         "node_modules/is-buffer": {
             "version": "2.0.5",
@@ -1438,14 +1578,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-plain-obj": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1453,19 +1585,49 @@
             "dev": true
         },
         "node_modules/it-all": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
-            "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+            "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==",
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
         },
         "node_modules/it-batch": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.9.tgz",
-            "integrity": "sha512-7Q7HXewMhNFltTsAMdSz6luNhyhkhEtGGbYek/8Xb/GiqYMtwUmopE1ocPSiJKKp3rM4Dt045sNFoUu+KZGNyA=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-2.0.1.tgz",
+            "integrity": "sha512-2gWFuPzamh9Dh3pW+OKjc7UwJ41W4Eu2AinVAfXDMfrC5gXfm3b1TF+1UzsygBUgKBugnxnGP+/fFRyn+9y1mQ==",
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/it-drain": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.1.tgz",
+            "integrity": "sha512-ESuHV6MLUNxuSy0vGZpKhSRjW0ixczN1FhbVy7eGJHjX6U2qiiXTyMvDc0z/w+nifOOwPyI5DT9Rc3o9IaGqEQ==",
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/it-filter": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.1.tgz",
+            "integrity": "sha512-w9pBEnqq0Ab+AZHqa4JlfRIhu1GKTPKXFSKHSh7w7ilKoHsT6wTASb2bDi/3/unvXuNo+cz/WH1yolov3WwgUg==",
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
         },
         "node_modules/it-first": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
-            "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.1.tgz",
+            "integrity": "sha512-noC1oEQcWZZMUwq7VWxHNLML43dM+5bviZpfmkxkXlvBe60z7AFRqpZSga9uQBo792jKv9otnn1IjA4zwgNARw==",
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
         },
         "node_modules/it-last": {
             "version": "1.0.6",
@@ -1473,11 +1635,24 @@
             "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
         },
         "node_modules/it-parallel-batch": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.11.tgz",
-            "integrity": "sha512-UWsWHv/kqBpMRmyZJzlmZeoAMA0F3SZr08FBdbhtbe+MtoEBgr/ZUAKrnenhXCBrsopy76QjRH2K/V8kNdupbQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-2.0.1.tgz",
+            "integrity": "sha512-tXh567/JfDGJ90Zi//H9HkL7kY27ARp0jf2vu2jUI6PUVBWfsoT+gC4eT41/b4+wkJXSGgT8ZHnivAOlMfcNjA==",
             "dependencies": {
-                "it-batch": "^1.0.9"
+                "it-batch": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/it-take": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/it-take/-/it-take-2.0.1.tgz",
+            "integrity": "sha512-DL7kpZNjuoeSTnB9dMAJ0Z3m2T29LRRAU+HIgkiQM+1jH3m8l9e/1xpWs8JHTlbKivbqSFrQMTc8KVcaQNmsaA==",
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
             }
         },
         "node_modules/js-sdsl": {
@@ -1542,60 +1717,6 @@
                 "url": "https://opencollective.com/level"
             }
         },
-        "node_modules/level-codec": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-10.0.0.tgz",
-            "integrity": "sha512-QW3VteVNAp6c/LuV6nDjg7XDXx9XHK4abmQarxZmlRSDyXYk20UdaJTSX6yzVvQ4i0JyWSB7jert0DsyD/kk6g==",
-            "dependencies": {
-                "buffer": "^6.0.3"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/level-concat-iterator": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
-            "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
-            "dependencies": {
-                "catering": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/level-errors": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-3.0.1.tgz",
-            "integrity": "sha512-tqTL2DxzPDzpwl0iV5+rBCv65HWbHp6eutluHNcVIftKZlQN//b6GEnZDM2CvGZvzGYMwyPtYppYnydBQd2SMQ==",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/level-iterator-stream": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-5.0.0.tgz",
-            "integrity": "sha512-wnb1+o+CVFUDdiSMR/ZymE2prPs3cjVLlXuDeSq9Zb8o032XrabGEXcTCsBxprAtseO3qvFeGzh6406z9sOTRA==",
-            "dependencies": {
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/level-js": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/level-js/-/level-js-6.1.0.tgz",
-            "integrity": "sha512-i7mPtkZm68aewfv0FnIUWvFUFfoyzIvVKnUmuQGrelEkP72vSPTaA1SGneWWoCV5KZJG4wlzbJLp1WxVNGuc6A==",
-            "dependencies": {
-                "abstract-leveldown": "^7.2.0",
-                "buffer": "^6.0.3",
-                "inherits": "^2.0.3",
-                "ltgt": "^2.1.2",
-                "run-parallel-limit": "^1.1.0"
-            }
-        },
         "node_modules/level-supports": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
@@ -1614,44 +1735,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/leveldown": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.1.tgz",
-            "integrity": "sha512-88c+E+Eizn4CkQOBHwqlCJaTNEjGpaEIikn1S+cINc5E9HEvJ77bqY4JY/HxT5u0caWqsc3P3DcFIKBI1vHt+A==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "abstract-leveldown": "^7.2.0",
-                "napi-macros": "~2.0.0",
-                "node-gyp-build": "^4.3.0"
-            },
-            "engines": {
-                "node": ">=10.12.0"
-            }
-        },
-        "node_modules/levelup": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/levelup/-/levelup-5.1.1.tgz",
-            "integrity": "sha512-0mFCcHcEebOwsQuk00WJwjLI6oCjbBuEYdh/RaRqhjnyVlzqf41T1NnDtCedumZ56qyIh8euLFDqV1KfzTAVhg==",
-            "dependencies": {
-                "catering": "^2.0.0",
-                "deferred-leveldown": "^7.0.0",
-                "level-errors": "^3.0.1",
-                "level-iterator-stream": "^5.0.0",
-                "level-supports": "^2.0.1",
-                "queue-microtask": "^1.2.3"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/levelup/node_modules/level-supports": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-            "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/levn": {
@@ -1706,22 +1789,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/ltgt": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-            "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA=="
-        },
-        "node_modules/merge-options": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-            "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-            "dependencies": {
-                "is-plain-obj": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1735,9 +1802,9 @@
             }
         },
         "node_modules/minimist": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -1829,11 +1896,6 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
-        "node_modules/ngraminator": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/ngraminator/-/ngraminator-3.0.2.tgz",
-            "integrity": "sha512-+9RehP0EFeNxCyD53aeSFvF3OU6V0zcoZNRCXxvISl+nnlFcIZxSYdGhPaq8NDJTGlA4Ej5+NlkGopRSuuAwfw=="
-        },
         "node_modules/node-fetch": {
             "version": "2.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -1919,32 +1981,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/p-queue": {
-            "version": "7.3.4",
-            "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
-            "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
-            "dependencies": {
-                "eventemitter3": "^4.0.7",
-                "p-timeout": "^5.0.2"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/p-timeout": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-            "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -1993,6 +2029,14 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
         "node_modules/prompts": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -2028,6 +2072,50 @@
             "bin": {
                 "pbjs": "bin/pbjs",
                 "pbts": "bin/pbts"
+            }
+        },
+        "node_modules/protons-runtime": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+            "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
+            "dependencies": {
+                "protobufjs": "^7.0.0",
+                "uint8arraylist": "^2.4.3"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            },
+            "peerDependencies": {
+                "uint8arraylist": "^2.3.2"
+            }
+        },
+        "node_modules/protons-runtime/node_modules/long": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+            "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+        },
+        "node_modules/protons-runtime/node_modules/protobufjs": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
+            "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/node": ">=13.7.0",
+                "long": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/punycode": {
@@ -2073,6 +2161,19 @@
                 "rabin-wasm": "cli/bin.js"
             }
         },
+        "node_modules/rabin-wasm/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -2082,16 +2183,17 @@
             }
         },
         "node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
+            "integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
             "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10"
             },
             "engines": {
-                "node": ">= 6"
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/regexpp": {
@@ -2212,23 +2314,6 @@
                 }
             ]
         },
-        "node_modules/search-index": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/search-index/-/search-index-3.1.3.tgz",
-            "integrity": "sha512-kck7BEbdmVV2NVIHCTg27I6NTDSQiyC1y/YTazmlzTN7+6o43eie0Vd3HBVyoqzDV0CnQeGv1k3XCDNo6mIaYQ==",
-            "dependencies": {
-                "fergies-inverted-index": "10.0.6",
-                "level-js": "^6.1.0",
-                "leveldown": "^6.1.1",
-                "lru-cache": "^7.9.0",
-                "ngraminator": "^3.0.1",
-                "p-queue": "^7.2.0",
-                "term-vector": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2304,14 +2389,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/term-vector": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/term-vector/-/term-vector-1.0.0.tgz",
-            "integrity": "sha512-P7xDawxO9T1yjR2oiTfgw7BzvyrdsbakUT6PJsgaAeFmSV+6h3fnXtmZJf4ynef6HVamYgs7Wf5I75UBV15ddQ==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -2322,14 +2399,6 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
-        "node_modules/traverse": {
-            "version": "0.6.7",
-            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.7.tgz",
-            "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/tslib": {
             "version": "2.5.0",
@@ -2358,6 +2427,30 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/uint8arraylist": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
+            "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
+            "dependencies": {
+                "uint8arrays": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/uint8arraylist/node_modules/uint8arrays": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+            "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+            "dependencies": {
+                "multiformats": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=7.0.0"
             }
         },
         "node_modules/uint8arrays": {
@@ -2573,19 +2666,12 @@
             "dev": true
         },
         "@ipld/dag-cbor": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.1.tgz",
-            "integrity": "sha512-XqG8VEzHjQDC/Qcy5Gyf1kvAav5VuAugc6c7VtdaRLI+3d8lJrUP3F76GYJNNXuEnRZ58cCBnNNglkIGTdg1+A==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.0.tgz",
+            "integrity": "sha512-zdsiSiYDEOIDW7mmWOYWC9gukjXO+F8wqxz/LfN7iSwTfIyipC8+UQrCbPupFMRb/33XQTZk8yl3My8vUQBRoA==",
             "requires": {
-                "cborg": "^1.6.0",
-                "multiformats": "^9.5.4"
-            },
-            "dependencies": {
-                "multiformats": {
-                    "version": "9.9.0",
-                    "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-                    "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-                }
+                "cborg": "^1.10.0",
+                "multiformats": "^11.0.0"
             }
         },
         "@ipld/dag-pb": {
@@ -2734,30 +2820,35 @@
             "integrity": "sha512-aWItSZvJj4+GI6FWkjZR13xPNPctq2RRakzo+O6vN7bC2yjwdg5EFpgaSAUn95b7BGSgcflvzVDPoKmJv24IOg=="
         },
         "@tbd54566975/dwn-sdk-js": {
-            "version": "0.0.19",
-            "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.0.19.tgz",
-            "integrity": "sha512-aiQ8TNAwDhjbvxL4bOIn70lOdJWFeT46AlvIIuVQDE+CaRp7DGFsiRWMOZuYejnN+d/NuoyPUHBDKM9tzHzNwA==",
+            "version": "0.0.26",
+            "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.0.26.tgz",
+            "integrity": "sha512-Bj+cesS5ePQ1a8k+x5DFDQFwL8gNidOicW+/+VC/KjMH2QLikCuWYdcW9A3toxPJqtTQLlfXDBp5vLeO94C7/Q==",
             "requires": {
-                "@ipld/dag-cbor": "7.0.1",
+                "@ipld/dag-cbor": "9.0.0",
                 "@js-temporal/polyfill": "0.4.3",
                 "@noble/ed25519": "1.7.1",
                 "@noble/secp256k1": "1.7.1",
                 "@swc/helpers": "0.3.8",
                 "@types/ms": "0.7.31",
+                "@types/node": "^18.13.0",
+                "@types/readable-stream": "2.3.15",
+                "abstract-level": "1.0.3",
                 "ajv": "8.11.0",
+                "blockstore-core": "3.0.0",
                 "cross-fetch": "3.1.5",
                 "date-fns": "2.28.0",
-                "interface-blockstore": "2.0.3",
+                "flat": "^5.0.2",
+                "interface-blockstore": "4.0.1",
                 "ipfs-unixfs": "6.0.9",
                 "ipfs-unixfs-exporter": "7.0.11",
-                "ipfs-unixfs-importer": "9.0.10",
+                "ipfs-unixfs-importer": "14.0.1",
                 "level": "8.0.0",
                 "lodash": "4.17.21",
                 "lru-cache": "7.12.0",
                 "ms": "2.1.3",
-                "multiformats": "9.6.4",
+                "multiformats": "11.0.2",
                 "randombytes": "2.1.0",
-                "search-index": "3.1.3",
+                "readable-stream": "4.3.0",
                 "uuid": "8.3.2",
                 "varint": "6.0.0"
             },
@@ -2772,10 +2863,24 @@
                     "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
                     "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
                 },
+                "interface-blockstore": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-4.0.1.tgz",
+                    "integrity": "sha512-ROWKGJls7vLeFaQtI3hZVCJOkUoZ05xAi2t2qysM4d7dwVKrfm5jUOqWh8JgLL7Iup3XqJ0mKXXZuwJ3s03RSw==",
+                    "requires": {
+                        "interface-store": "^3.0.0",
+                        "multiformats": "^11.0.0"
+                    }
+                },
+                "interface-store": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+                    "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ=="
+                },
                 "multiformats": {
-                    "version": "9.6.4",
-                    "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.4.tgz",
-                    "integrity": "sha512-fCCB6XMrr6CqJiHNjfFNGT0v//dxOBMrOMqUIzpPc/mmITweLEyhvMpY9bF+jZ9z3vaMAau5E8B68DW77QMXkg=="
+                    "version": "11.0.2",
+                    "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+                    "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
                 },
                 "uuid": {
                     "version": "8.3.2",
@@ -2799,6 +2904,30 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
             "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
         },
+        "@types/readable-stream": {
+            "version": "2.3.15",
+            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+            "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+            "requires": {
+                "@types/node": "*",
+                "safe-buffer": "~5.1.1"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                }
+            }
+        },
+        "abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "requires": {
+                "event-target-shim": "^5.0.0"
+            }
+        },
         "abstract-level": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
@@ -2811,26 +2940,6 @@
                 "level-transcoder": "^1.0.1",
                 "module-error": "^1.0.1",
                 "queue-microtask": "^1.2.3"
-            }
-        },
-        "abstract-leveldown": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-            "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
-            "requires": {
-                "buffer": "^6.0.3",
-                "catering": "^2.0.0",
-                "is-buffer": "^2.0.5",
-                "level-concat-iterator": "^3.0.0",
-                "level-supports": "^2.0.1",
-                "queue-microtask": "^1.2.3"
-            },
-            "dependencies": {
-                "level-supports": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-                    "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA=="
-                }
             }
         },
         "acorn": {
@@ -2897,6 +3006,49 @@
                 "buffer": "^6.0.3",
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.2",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+                    "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "blockstore-core": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/blockstore-core/-/blockstore-core-3.0.0.tgz",
+            "integrity": "sha512-5ZZB5nh6kErcjZ/CTK6lCwTIGlPdkTXbD8+2xLC4Fm0WGh7g2e2lW2bfURw7mvnPtSX1xV+sN4V2ndowSgIiHQ==",
+            "requires": {
+                "err-code": "^3.0.1",
+                "interface-blockstore": "^4.0.0",
+                "interface-store": "^3.0.0",
+                "it-all": "^2.0.0",
+                "it-drain": "^2.0.0",
+                "it-filter": "^2.0.0",
+                "it-take": "^2.0.0",
+                "multiformats": "^11.0.0"
+            },
+            "dependencies": {
+                "interface-blockstore": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-4.0.1.tgz",
+                    "integrity": "sha512-ROWKGJls7vLeFaQtI3hZVCJOkUoZ05xAi2t2qysM4d7dwVKrfm5jUOqWh8JgLL7Iup3XqJ0mKXXZuwJ3s03RSw==",
+                    "requires": {
+                        "interface-store": "^3.0.0",
+                        "multiformats": "^11.0.0"
+                    }
+                },
+                "interface-store": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+                    "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ=="
+                }
             }
         },
         "brace-expansion": {
@@ -2959,11 +3111,6 @@
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
             }
-        },
-        "charwise": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
-            "integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw=="
         },
         "classic-level": {
             "version": "1.2.0",
@@ -3048,15 +3195,6 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
         },
-        "deferred-leveldown": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-7.0.0.tgz",
-            "integrity": "sha512-QKN8NtuS3BC6m0B8vAnBls44tX1WXAFATUsJlruyAYbZpysWV3siH6o/i3g9DCHauzodksO60bdj5NazNbjCmg==",
-            "requires": {
-                "abstract-leveldown": "^7.2.0",
-                "inherits": "^2.0.3"
-            }
-        },
         "doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -3064,17 +3202,6 @@
             "dev": true,
             "requires": {
                 "esutils": "^2.0.2"
-            }
-        },
-        "encoding-down": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-7.1.0.tgz",
-            "integrity": "sha512-ky47X5jP84ryk5EQmvedQzELwVJPjCgXDQZGeb9F6r4PdChByCGHTBrVcF3h8ynKVJ1wVbkxTsDC8zBROPypgQ==",
-            "requires": {
-                "abstract-leveldown": "^7.2.0",
-                "inherits": "^2.0.3",
-                "level-codec": "^10.0.0",
-                "level-errors": "^3.0.0"
             }
         },
         "err-code": {
@@ -3229,10 +3356,15 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
         },
-        "eventemitter3": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+        "event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+        },
+        "events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -3260,19 +3392,6 @@
                 "reusify": "^1.0.4"
             }
         },
-        "fergies-inverted-index": {
-            "version": "10.0.6",
-            "resolved": "https://registry.npmjs.org/fergies-inverted-index/-/fergies-inverted-index-10.0.6.tgz",
-            "integrity": "sha512-T0dXoUk7XYr/N4Vgcw8MDoKtSUedYp9KxPvyYLSFbqIxDoOBPXpOktSTDaA6ToU9u9o/7u4FXtd9vJ4AoQejZg==",
-            "requires": {
-                "charwise": "^3.0.1",
-                "encoding-down": "^7.1.0",
-                "level-js": "^6.1.0",
-                "leveldown": "^6.1.0",
-                "levelup": "^5.1.1",
-                "traverse": "^0.6.6"
-            }
-        },
         "file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3291,6 +3410,11 @@
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
             }
+        },
+        "flat": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
         },
         "flat-cache": {
             "version": "3.0.4",
@@ -3503,31 +3627,83 @@
             }
         },
         "ipfs-unixfs-importer": {
-            "version": "9.0.10",
-            "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.10.tgz",
-            "integrity": "sha512-W+tQTVcSmXtFh7FWYWwPBGXJ1xDgREbIyI1E5JzDcimZLIyT5gGMfxR3oKPxxWj+GKMpP5ilvMQrbsPzWcm3Fw==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-14.0.1.tgz",
+            "integrity": "sha512-ktsXRDC3AraX6Z3NbKREOcHlcYm0o4j2J7ygJLn3N1DpIbUPNmX5z3wl45DMH5b2HIZVqnS68VxKyr9H9LLhnw==",
             "requires": {
-                "@ipld/dag-pb": "^2.0.2",
-                "@multiformats/murmur3": "^1.0.3",
-                "bl": "^5.0.0",
+                "@ipld/dag-pb": "^4.0.0",
+                "@multiformats/murmur3": "^2.0.0",
                 "err-code": "^3.0.1",
-                "hamt-sharding": "^2.0.0",
-                "interface-blockstore": "^2.0.3",
-                "ipfs-unixfs": "^6.0.0",
-                "it-all": "^1.0.5",
-                "it-batch": "^1.0.8",
-                "it-first": "^1.0.6",
-                "it-parallel-batch": "^1.0.9",
-                "merge-options": "^3.0.4",
-                "multiformats": "^9.4.2",
+                "hamt-sharding": "^3.0.0",
+                "interface-blockstore": "^4.0.0",
+                "ipfs-unixfs": "^11.0.0",
+                "it-all": "^2.0.0",
+                "it-batch": "^2.0.0",
+                "it-first": "^2.0.0",
+                "it-parallel-batch": "^2.0.0",
+                "multiformats": "^11.0.0",
                 "rabin-wasm": "^0.1.4",
-                "uint8arrays": "^3.0.0"
+                "uint8arraylist": "^2.4.3",
+                "uint8arrays": "^4.0.2"
             },
             "dependencies": {
-                "multiformats": {
-                    "version": "9.9.0",
-                    "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-                    "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+                "@ipld/dag-pb": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.2.tgz",
+                    "integrity": "sha512-me9oEPb7UNPWSplUFCXyxnQE3/WlsjOljqO2RZN44XOmGkBY0/WVklbXorVE1eiv0Rt3p6dBS2x36Rq8A0Am8A==",
+                    "requires": {
+                        "multiformats": "^11.0.0"
+                    }
+                },
+                "@multiformats/murmur3": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.3.tgz",
+                    "integrity": "sha512-YvLK1IrLnRckPsvXhOkZjaIGNonsEdD1dL3NPSaLilV/WjVYeBgnNZXTUsaPzFXGrIFM7motx+yCmmqzXO6gtQ==",
+                    "requires": {
+                        "multiformats": "^11.0.0",
+                        "murmurhash3js-revisited": "^3.0.0"
+                    }
+                },
+                "hamt-sharding": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.2.tgz",
+                    "integrity": "sha512-f0DzBD2tSmLFdFsLAvOflIBqFPjerbA7BfmwO8mVho/5hXwgyyYhv+ijIzidQf/DpDX3bRjAQvhGoBFj+DBvPw==",
+                    "requires": {
+                        "sparse-array": "^1.3.1",
+                        "uint8arrays": "^4.0.2"
+                    }
+                },
+                "interface-blockstore": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-4.0.1.tgz",
+                    "integrity": "sha512-ROWKGJls7vLeFaQtI3hZVCJOkUoZ05xAi2t2qysM4d7dwVKrfm5jUOqWh8JgLL7Iup3XqJ0mKXXZuwJ3s03RSw==",
+                    "requires": {
+                        "interface-store": "^3.0.0",
+                        "multiformats": "^11.0.0"
+                    }
+                },
+                "interface-store": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+                    "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ=="
+                },
+                "ipfs-unixfs": {
+                    "version": "11.0.0",
+                    "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.0.0.tgz",
+                    "integrity": "sha512-ZHTTzP5yuimLTln+8VKc3IcsO4ObS6/U8eZ3CA69s1DdW9uBfyjEo6/GTZA80yokHVGWvmCl1S28zmJ5JskP4Q==",
+                    "requires": {
+                        "err-code": "^3.0.1",
+                        "protons-runtime": "^5.0.0",
+                        "uint8arraylist": "^2.4.3"
+                    }
+                },
+                "uint8arrays": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+                    "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+                    "requires": {
+                        "multiformats": "^11.0.0"
+                    }
                 }
             }
         },
@@ -3557,11 +3733,6 @@
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "dev": true
         },
-        "is-plain-obj": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
-        },
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3569,19 +3740,29 @@
             "dev": true
         },
         "it-all": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
-            "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.1.tgz",
+            "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA=="
         },
         "it-batch": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.9.tgz",
-            "integrity": "sha512-7Q7HXewMhNFltTsAMdSz6luNhyhkhEtGGbYek/8Xb/GiqYMtwUmopE1ocPSiJKKp3rM4Dt045sNFoUu+KZGNyA=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-2.0.1.tgz",
+            "integrity": "sha512-2gWFuPzamh9Dh3pW+OKjc7UwJ41W4Eu2AinVAfXDMfrC5gXfm3b1TF+1UzsygBUgKBugnxnGP+/fFRyn+9y1mQ=="
+        },
+        "it-drain": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-2.0.1.tgz",
+            "integrity": "sha512-ESuHV6MLUNxuSy0vGZpKhSRjW0ixczN1FhbVy7eGJHjX6U2qiiXTyMvDc0z/w+nifOOwPyI5DT9Rc3o9IaGqEQ=="
+        },
+        "it-filter": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-2.0.1.tgz",
+            "integrity": "sha512-w9pBEnqq0Ab+AZHqa4JlfRIhu1GKTPKXFSKHSh7w7ilKoHsT6wTASb2bDi/3/unvXuNo+cz/WH1yolov3WwgUg=="
         },
         "it-first": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
-            "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.1.tgz",
+            "integrity": "sha512-noC1oEQcWZZMUwq7VWxHNLML43dM+5bviZpfmkxkXlvBe60z7AFRqpZSga9uQBo792jKv9otnn1IjA4zwgNARw=="
         },
         "it-last": {
             "version": "1.0.6",
@@ -3589,12 +3770,17 @@
             "integrity": "sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q=="
         },
         "it-parallel-batch": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.11.tgz",
-            "integrity": "sha512-UWsWHv/kqBpMRmyZJzlmZeoAMA0F3SZr08FBdbhtbe+MtoEBgr/ZUAKrnenhXCBrsopy76QjRH2K/V8kNdupbQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-2.0.1.tgz",
+            "integrity": "sha512-tXh567/JfDGJ90Zi//H9HkL7kY27ARp0jf2vu2jUI6PUVBWfsoT+gC4eT41/b4+wkJXSGgT8ZHnivAOlMfcNjA==",
             "requires": {
-                "it-batch": "^1.0.9"
+                "it-batch": "^2.0.0"
             }
+        },
+        "it-take": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/it-take/-/it-take-2.0.1.tgz",
+            "integrity": "sha512-DL7kpZNjuoeSTnB9dMAJ0Z3m2T29LRRAU+HIgkiQM+1jH3m8l9e/1xpWs8JHTlbKivbqSFrQMTc8KVcaQNmsaA=="
         },
         "js-sdsl": {
             "version": "4.3.0",
@@ -3641,48 +3827,6 @@
                 "classic-level": "^1.2.0"
             }
         },
-        "level-codec": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-10.0.0.tgz",
-            "integrity": "sha512-QW3VteVNAp6c/LuV6nDjg7XDXx9XHK4abmQarxZmlRSDyXYk20UdaJTSX6yzVvQ4i0JyWSB7jert0DsyD/kk6g==",
-            "requires": {
-                "buffer": "^6.0.3"
-            }
-        },
-        "level-concat-iterator": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
-            "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
-            "requires": {
-                "catering": "^2.1.0"
-            }
-        },
-        "level-errors": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-3.0.1.tgz",
-            "integrity": "sha512-tqTL2DxzPDzpwl0iV5+rBCv65HWbHp6eutluHNcVIftKZlQN//b6GEnZDM2CvGZvzGYMwyPtYppYnydBQd2SMQ=="
-        },
-        "level-iterator-stream": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-5.0.0.tgz",
-            "integrity": "sha512-wnb1+o+CVFUDdiSMR/ZymE2prPs3cjVLlXuDeSq9Zb8o032XrabGEXcTCsBxprAtseO3qvFeGzh6406z9sOTRA==",
-            "requires": {
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
-        },
-        "level-js": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/level-js/-/level-js-6.1.0.tgz",
-            "integrity": "sha512-i7mPtkZm68aewfv0FnIUWvFUFfoyzIvVKnUmuQGrelEkP72vSPTaA1SGneWWoCV5KZJG4wlzbJLp1WxVNGuc6A==",
-            "requires": {
-                "abstract-leveldown": "^7.2.0",
-                "buffer": "^6.0.3",
-                "inherits": "^2.0.3",
-                "ltgt": "^2.1.2",
-                "run-parallel-limit": "^1.1.0"
-            }
-        },
         "level-supports": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
@@ -3695,36 +3839,6 @@
             "requires": {
                 "buffer": "^6.0.3",
                 "module-error": "^1.0.1"
-            }
-        },
-        "leveldown": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.1.tgz",
-            "integrity": "sha512-88c+E+Eizn4CkQOBHwqlCJaTNEjGpaEIikn1S+cINc5E9HEvJ77bqY4JY/HxT5u0caWqsc3P3DcFIKBI1vHt+A==",
-            "requires": {
-                "abstract-leveldown": "^7.2.0",
-                "napi-macros": "~2.0.0",
-                "node-gyp-build": "^4.3.0"
-            }
-        },
-        "levelup": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/levelup/-/levelup-5.1.1.tgz",
-            "integrity": "sha512-0mFCcHcEebOwsQuk00WJwjLI6oCjbBuEYdh/RaRqhjnyVlzqf41T1NnDtCedumZ56qyIh8euLFDqV1KfzTAVhg==",
-            "requires": {
-                "catering": "^2.0.0",
-                "deferred-leveldown": "^7.0.0",
-                "level-errors": "^3.0.1",
-                "level-iterator-stream": "^5.0.0",
-                "level-supports": "^2.0.1",
-                "queue-microtask": "^1.2.3"
-            },
-            "dependencies": {
-                "level-supports": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-                    "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA=="
-                }
             }
         },
         "levn": {
@@ -3767,19 +3881,6 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.12.0.tgz",
             "integrity": "sha512-OIP3DwzRZDfLg9B9VP/huWBlpvbkmbfiBy8xmsXp4RPmE4A3MhwNozc5ZJ3fWnSg8fDcdlE/neRTPG2ycEKliw=="
         },
-        "ltgt": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-            "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA=="
-        },
-        "merge-options": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-            "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-            "requires": {
-                "is-plain-obj": "^2.1.0"
-            }
-        },
         "minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3790,9 +3891,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
         },
         "mkdirp": {
             "version": "2.1.3",
@@ -3855,11 +3956,6 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
-        "ngraminator": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/ngraminator/-/ngraminator-3.0.2.tgz",
-            "integrity": "sha512-+9RehP0EFeNxCyD53aeSFvF3OU6V0zcoZNRCXxvISl+nnlFcIZxSYdGhPaq8NDJTGlA4Ej5+NlkGopRSuuAwfw=="
-        },
         "node-fetch": {
             "version": "2.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -3914,20 +4010,6 @@
                 "p-limit": "^3.0.2"
             }
         },
-        "p-queue": {
-            "version": "7.3.4",
-            "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
-            "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
-            "requires": {
-                "eventemitter3": "^4.0.7",
-                "p-timeout": "^5.0.2"
-            }
-        },
-        "p-timeout": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-            "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
-        },
         "parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3961,6 +4043,11 @@
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true
         },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+        },
         "prompts": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -3990,6 +4077,41 @@
                 "long": "^4.0.0"
             }
         },
+        "protons-runtime": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
+            "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
+            "requires": {
+                "protobufjs": "^7.0.0",
+                "uint8arraylist": "^2.4.3"
+            },
+            "dependencies": {
+                "long": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+                    "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+                },
+                "protobufjs": {
+                    "version": "7.2.2",
+                    "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
+                    "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
+                    "requires": {
+                        "@protobufjs/aspromise": "^1.1.2",
+                        "@protobufjs/base64": "^1.1.2",
+                        "@protobufjs/codegen": "^2.0.4",
+                        "@protobufjs/eventemitter": "^1.1.0",
+                        "@protobufjs/fetch": "^1.1.0",
+                        "@protobufjs/float": "^1.0.2",
+                        "@protobufjs/inquire": "^1.1.0",
+                        "@protobufjs/path": "^1.1.2",
+                        "@protobufjs/pool": "^1.1.0",
+                        "@protobufjs/utf8": "^1.1.0",
+                        "@types/node": ">=13.7.0",
+                        "long": "^5.0.0"
+                    }
+                }
+            }
+        },
         "punycode": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -4011,6 +4133,18 @@
                 "minimist": "^1.2.5",
                 "node-fetch": "^2.6.1",
                 "readable-stream": "^3.6.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.2",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+                    "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
             }
         },
         "randombytes": {
@@ -4022,13 +4156,14 @@
             }
         },
         "readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
+            "integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
             "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10"
             }
         },
         "regexpp": {
@@ -4084,20 +4219,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "search-index": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/search-index/-/search-index-3.1.3.tgz",
-            "integrity": "sha512-kck7BEbdmVV2NVIHCTg27I6NTDSQiyC1y/YTazmlzTN7+6o43eie0Vd3HBVyoqzDV0CnQeGv1k3XCDNo6mIaYQ==",
-            "requires": {
-                "fergies-inverted-index": "10.0.6",
-                "level-js": "^6.1.0",
-                "leveldown": "^6.1.1",
-                "lru-cache": "^7.9.0",
-                "ngraminator": "^3.0.1",
-                "p-queue": "^7.2.0",
-                "term-vector": "^1.0.0"
-            }
         },
         "shebang-command": {
             "version": "2.0.0",
@@ -4156,11 +4277,6 @@
                 "has-flag": "^4.0.0"
             }
         },
-        "term-vector": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/term-vector/-/term-vector-1.0.0.tgz",
-            "integrity": "sha512-P7xDawxO9T1yjR2oiTfgw7BzvyrdsbakUT6PJsgaAeFmSV+6h3fnXtmZJf4ynef6HVamYgs7Wf5I75UBV15ddQ=="
-        },
         "text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4171,11 +4287,6 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
-        "traverse": {
-            "version": "0.6.7",
-            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.7.tgz",
-            "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg=="
         },
         "tslib": {
             "version": "2.5.0",
@@ -4196,6 +4307,24 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true
+        },
+        "uint8arraylist": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
+            "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
+            "requires": {
+                "uint8arrays": "^4.0.2"
+            },
+            "dependencies": {
+                "uint8arrays": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
+                    "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
+                    "requires": {
+                        "multiformats": "^11.0.0"
+                    }
+                }
+            }
         },
         "uint8arrays": {
             "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "multiformats": "11.0.1",
         "prompts": "2.4.2",
         "@decentralized-identity/ion-tools": "1.0.3",
-        "@tbd54566975/dwn-sdk-js": "0.0.19"
+        "@tbd54566975/dwn-sdk-js": "0.0.26"
     },
     "devDependencies": {
         "eslint": "8.33.0"

--- a/src/cli/add/contact.js
+++ b/src/cli/add/contact.js
@@ -14,7 +14,7 @@ cmd.option('-h, --handle [handle]', 'a friendly handle. Did\'s are long and ugly
 cmd.action(async () => {
   let { did, handle } = cmd.opts();
   const questions = [];
-  
+
   if (!did) {
     questions.push(interactivePrompts.did);
   }
@@ -31,9 +31,9 @@ cmd.action(async () => {
   }
 
   const contact = new Contact(did, handle);
-  const dWebMessage = await contact.toDWebMessage(DidLoader.getSignatureMaterial());
+  const { message: dWebMessage, data } = await contact.toDWebMessage(DidLoader.getSignatureMaterial());
 
-  const result = await RemoteDwnClient.send(dWebMessage, DidLoader.getDid());
+  const result = await RemoteDwnClient.send(dWebMessage, DidLoader.getDid(), data);
 
   if (result.status.code !== 202) {
     throw new Error('failed to add contact');
@@ -44,15 +44,15 @@ cmd.action(async () => {
 
 const interactivePrompts = {
   did: {
-    type    : 'text',
-    name    : 'did',
-    message : 'what\'s the contact\'s did?',
-  
+    type: 'text',
+    name: 'did',
+    message: 'what\'s the contact\'s did?',
+
   },
   handle: {
-    type    : 'text',
-    name    : 'handle',
-    message : 'provide a friendly handle. Did\'s are long and ugly',
+    type: 'text',
+    name: 'handle',
+    message: 'provide a friendly handle. Did\'s are long and ugly',
   }
 };
 

--- a/src/did/did-loader.js
+++ b/src/did/did-loader.js
@@ -21,7 +21,7 @@ if (fs.existsSync(config.did.storagePath)) {
 
       // Pick 3 random endpoints
       let randomEndpoints = [];
-      while (randomEndpoints.length < 1) {
+      while (randomEndpoints.length < 3) {
         let randomIndex = Math.floor(Math.random() * endpoints.length);
         if (!randomEndpoints.includes(endpoints[randomIndex])) {
           randomEndpoints.push(endpoints[randomIndex]);

--- a/src/did/did-loader.js
+++ b/src/did/did-loader.js
@@ -10,27 +10,24 @@ if (fs.existsSync(config.did.storagePath)) {
   didState = JSON.parse(didStateJson);
 } else {
   if (config.did.method === 'ion') {
-
-
-
     const endpoints = [
-                    'https://dwn-usa-1.ue8cktdq71va0.us-east-2.cs.amazonlightsail.com/', 
-                    'https://dwn-aggregator.faktj7f1fndve.ap-southeast-2.cs.amazonlightsail.com/',
-                    'https://dwn-india.vtv94qck5sjvq.ap-south-1.cs.amazonlightsail.com/'
-                  ];
-                  
+      'https://dwn-usa-1.ue8cktdq71va0.us-east-2.cs.amazonlightsail.com/',
+      'https://dwn-aggregator.faktj7f1fndve.ap-southeast-2.cs.amazonlightsail.com/',
+      'https://dwn-india.vtv94qck5sjvq.ap-south-1.cs.amazonlightsail.com/'
+    ];
+
     const selectedEndpoints = async () => {
       let responseTimes = [];
-      
+
       // Pick 3 random endpoints
       let randomEndpoints = [];
-      while (randomEndpoints.length < 3) {
+      while (randomEndpoints.length < 1) {
         let randomIndex = Math.floor(Math.random() * endpoints.length);
         if (!randomEndpoints.includes(endpoints[randomIndex])) {
           randomEndpoints.push(endpoints[randomIndex]);
         }
       }
-      
+
       // Check the response time of each endpoint and make sure it returns 200 OK
       for (let endpoint of randomEndpoints) {
         let start = performance.now();
@@ -43,10 +40,10 @@ if (fs.existsSync(config.did.storagePath)) {
           });
         }
       }
-      
+
       // Sort the endpoints based on response time, fastest first
       responseTimes.sort((a, b) => a.responseTime - b.responseTime);
-      
+
       return responseTimes.map(rt => rt.endpoint);
     }
 

--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -5,7 +5,7 @@ export class Contact {
   #did;
   #handle;
   #message;
-  
+
   constructor(did, handle) {
     this.#did = did;
     this.#handle = handle;
@@ -30,40 +30,40 @@ export class Contact {
   get dateCreated() {
     return this.#message.descriptor.dateCreated;
   }
-  
+
   async toDWebMessage(signatureInput) {
     if (this.#message) {
       return this.#message;
     }
-    
+
     const rawContact = {
-      did    : this.#did,
-      handle : this.#handle
+      did: this.#did,
+      handle: this.#handle
     };
 
     const dataStringified = JSON.stringify(rawContact);
     const dataBytes = new TextEncoder().encode(dataStringified);
-    
+
     const message = await RecordsWrite.create({
-      data                        : dataBytes, 
-      dataFormat                  : 'application/json',
-      schema                      : 'contact',
-      authorizationSignatureInput : signatureInput,
+      data: dataBytes,
+      dataFormat: 'application/json',
+      schema: 'contact',
+      authorizationSignatureInput: signatureInput,
     });
 
     this.#message = message.toJSON();
 
-    return this.#message;
+    return { message: this.#message, data: dataBytes };
   }
 
   static fromDWebMessage(message) {
     const { encodedData } = message;
-    
+
     const dataBytes = base64url.baseDecode(encodedData);
     const dataStringified = new TextDecoder().decode(dataBytes);
-    
+
     const { did, handle } = JSON.parse(dataStringified);
-    
+
     const contact = new Contact(did, handle);
     contact.#message = message;
 

--- a/src/models/dm.js
+++ b/src/models/dm.js
@@ -5,7 +5,7 @@ export class DM {
   #content;
   #message;
   #threadId;
-  
+
   constructor(content, threadId) {
     this.#content = content;
     this.#threadId = threadId;
@@ -16,12 +16,12 @@ export class DM {
   }
 
   get author() {
-    const [ signature ] = this.#message.attestation.signatures;
+    const [signature] = this.#message.attestation.signatures;
     const protectedHeaderBytes = base64url.baseDecode(signature.protected);
     const protectedHeaderString = new TextDecoder().decode(protectedHeaderBytes);
     const { kid } = JSON.parse(protectedHeaderString);
 
-    const [ did ] = kid.split('#');
+    const [did] = kid.split('#');
 
     return did;
   }
@@ -33,7 +33,7 @@ export class DM {
   get recordId() {
     return this.#message.recordId;
   }
-  
+
   get contextId() {
     return this.#message.contextId;
   }
@@ -45,44 +45,44 @@ export class DM {
   get dateCreated() {
     return this.#message.descriptor.dateCreated;
   }
-  
+
   async toDWebMessage(signatureInput) {
     if (this.#message) {
       return this.#message;
     }
-    
+
     const rawDM = {
       content: this.#content
     };
 
     const dataStringified = JSON.stringify(rawDM);
     const dataBytes = new TextEncoder().encode(dataStringified);
-    
+
     const message = await RecordsWrite.create({
-      contextId                   : this.#threadId,
-      data                        : dataBytes, 
-      dataFormat                  : 'application/json',
-      parentId                    : this.#threadId,
-      protocol                    : 'heyo',
-      published                   : true,
-      schema                      : 'heyo/dm',
-      authorizationSignatureInput : signatureInput,
-      attestationSignatureInputs  : [signatureInput]
+      contextId: this.#threadId,
+      data: dataBytes,
+      dataFormat: 'application/json',
+      parentId: this.#threadId,
+      protocol: 'heyo',
+      published: true,
+      schema: 'heyo/dm',
+      authorizationSignatureInput: signatureInput,
+      attestationSignatureInputs: [signatureInput]
     });
 
     this.#message = message.toJSON();
 
-    return this.#message;
+    return { message: this.#message, data: dataBytes };
   }
 
   static fromDWebMessage(message) {
     const { encodedData } = message;
-    
+
     const dataBytes = base64url.baseDecode(encodedData);
     const dataStringified = new TextDecoder().decode(dataBytes);
-    
+
     const { content } = JSON.parse(dataStringified);
-    
+
     const dm = new DM(content);
     dm.#message = message;
 

--- a/src/models/thread.js
+++ b/src/models/thread.js
@@ -4,18 +4,18 @@ import { base64url } from 'multiformats/bases/base64';
 export class Thread {
   #message;
   #threadWith;
-  
+
   constructor(threadWith) {
     this.#threadWith = threadWith;
   }
 
   get author() {
-    const [ signature ] = this.#message.attestation.signatures;
+    const [signature] = this.#message.attestation.signatures;
     const protectedHeaderBytes = base64url.baseDecode(signature.protected);
     const protectedHeaderString = new TextDecoder().decode(protectedHeaderBytes);
     const { kid } = JSON.parse(protectedHeaderString);
 
-    const [ did ] = kid.split('#');
+    const [did] = kid.split('#');
 
     return did;
   }
@@ -27,7 +27,7 @@ export class Thread {
   get recordId() {
     return this.#message.recordId;
   }
-  
+
   get contextId() {
     return this.#message.contextId;
   }
@@ -35,42 +35,42 @@ export class Thread {
   get dateCreated() {
     return this.#message.descriptor.dateCreated;
   }
-  
+
   async toDWebMessage(signatureInput) {
     if (this.#message) {
       return this.#message;
     }
-    
+
     const rawThread = {
       threadWith: this.#threadWith
     };
 
     const dataStringified = JSON.stringify(rawThread);
     const dataBytes = new TextEncoder().encode(dataStringified);
-    
+
     const message = await RecordsWrite.create({
-      data                        : dataBytes, 
-      dataFormat                  : 'application/json',
-      protocol                    : 'heyo',
-      recipient                   : this.#threadWith,
-      schema                      : 'heyo/thread',
-      authorizationSignatureInput : signatureInput,
-      attestationSignatureInputs  : [signatureInput]
+      data: dataBytes,
+      dataFormat: 'application/json',
+      protocol: 'heyo',
+      recipient: this.#threadWith,
+      schema: 'heyo/thread',
+      authorizationSignatureInput: signatureInput,
+      attestationSignatureInputs: [signatureInput]
     });
 
     this.#message = message.toJSON();
 
-    return this.#message;
+    return { message: this.#message, data: dataBytes };
   }
 
   static fromDWebMessage(message) {
     const { encodedData } = message;
-    
+
     const dataBytes = base64url.baseDecode(encodedData);
     const dataStringified = new TextDecoder().decode(dataBytes);
-    
+
     const { threadWith } = JSON.parse(dataStringified);
-    
+
     const thread = new Thread(threadWith);
     thread.#message = message;
 


### PR DESCRIPTION
> 💡  assumes: 
> * aggregators have been redeployed.
> * aggregator host addresses haven't changed from the host addresses in `did/did-loader`. will need to update these to reflect new addresses otherwise
> * `etc` directory has been deleted (cli was used before)